### PR TITLE
Update php version for D8

### DIFF
--- a/php_lib.info.yml
+++ b/php_lib.info.yml
@@ -2,5 +2,5 @@ name: 'PHP Lib'
 description: 'A collection of interfaces classes and functions that can be used in a variety of environments.'
 package: 'Islandora Dependencies'
 core: 8.x
-php: '5.5.9'
+php: '7.2'
 type: module


### PR DESCRIPTION
php 5 support is being dropped:
[Drupal docs](https://www.drupal.org/docs/8/system-requirements/php-requirements)